### PR TITLE
Separate generate functions for different combinations of return values

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,19 +6,23 @@
 
 Note: this package is designed to be used only with the "parametric" version of POMDPs (i.e. a version that exports POMDP{S,A,O} rather than POMDP).
 
-This package extends POMDPs.jl by providing a single interface function that makes implementing and solving problems with generative models easier.
+This package extends POMDPs.jl by providing a small collection of functions that makes implementing and solving problems with generative models easier.
 
-For POMDPs, this function is
+The functions are:
 ```julia
-generate{S,A,O}(p::POMDP{S,A,O}, s::S, a::A, rng::AbstractRNG) -> (sp::S, o::O, r)
+generate_s{S}(p::POMDP{S}, s, a, rng::AbstractRNG) -> sp::S
+generate_o{S,A,O}(p::POMDP{S,A,O}, s, a, sp, rng::AbstractRNG) -> o::O
+generate_sr{S}(p::POMDP{S}, s, a, rng::AbstractRNG) -> (s::S, r)
+generate_so{S,A,O}(p::POMDP{S,A,O}, s, a, rng::AbstractRNG) -> (s::S, o::O)
+generate_or{S,A,O}(p::POMDP{S,A,O}, s, a, sp, rng::AbstractRNG) -> (o::O, r)
+generate_sor{S,A,O}(p::POMDP{S,A,O}, s, a, rng::AbstractRNG) -> (s::S, o::O, r)
 ```
-and, for MDPs, it is
-```julia
-generate{S,A}(p::MDP{S,A}, s::S, a::A, rng::AbstractRNG) -> (sp::S, r)
-```
-(see below for more details (i.e. optional arguments, etc.))
 
-This function should return a sample next state, `sp`, observation, `o`, and reward `r`. Many solvers, for example MCTS and its derivatives such as POMCP, only require a generative model and never require explicit distributions. If these solvers use the `generate` function, the problem writer may implement `generate()` *instead of* `transition()` and `observation()`
+Note that in POMDPs.jl, an `MDP{S,A}` is a `POMDP{S,A,S}`, so all of these functions apply to MDPs as well as POMDPs (see below for more details (i.e. optional arguments, etc.)).
+
+These functions should return the appropriate combination of a sampled next state, `sp`, sampled observation, `o`, and reward `r`. Many solvers, for example MCTS and its derivatives such as POMCP, only require a generative model and never require explicit distributions. If these solvers use only `generate_` functions, the problem writer may implement `generate_...()` **instead of** `transition()` and `observation()`.
+
+A problem writer will generally only have to implement one or two of these functions for all solvers to work (see below).
 
 ## Installation
 
@@ -32,22 +36,20 @@ The function `generate()` also has optional trailing arguments for preallocated 
 
 The full method signatures are
 ```julia
-generate{S,A,O}(p::POMDP{S,A,O}, s::S, a::A, rng::AbstractRNG, sp::S=S(), o::O=O()
-```
-and
-```julia
-generate{S,A}(p::MDP{S,A}, s::S, a::A, rng::AbstractRNG, sp::S=S())
+generate_s{S}(p::POMDP{S}, s, a, rng::AbstractRNG, sp::S=S())
+generate_o{S,A,O}(p::POMDP{S,A,O}, s, a, sp, rng::AbstractRNG, o::O=O())
+generate_sr{S}(p::POMDP{S}, s, a, rng::AbstractRNG, sp::S=S())
+generate_so{S,A,O}(p::POMDP{S,A,O}, s, a, rng::AbstractRNG, sp::S=S(), o::O=O())
+generate_or{S,A,O}(p::POMDP{S,A,O}, s, a, sp, rng::AbstractRNG, o::O=O())
+generate_sor{S,A,O}(p::POMDP{S,A,O}, s, a, rng::AbstractRNG, sp::S=S(), o::O=O())
 ```
 
-The following default implementation is provided for problems that don't implement a specialized version of `generate()`. This is inefficient because new distributions are allocated at each timestep. A more efficient solution may be added in the future.
+Default implementations of the functions are provided in `src/GenerativeModels.jl` so that, if the problem implementer has implemented `transition()`, `observation()`, and `rand()` appropriately, the `generate_` functions will be automatically available for solvers to use, though this implementation is potentially inefficient because a new distribution is allocated every time a state is generated.
 
-```julia
-function generate{S,A,O}(p::POMDP{S,A,O}, s::S, a::A, rng::AbstractRNG, sp::S=S(), o::O=O())
-    td = transition(p, s, a)
-    sp = rand(rng, td, sp)
-    od = observation(p, s, a, sp)
-    o = rand(rng, od, o)
-    r = reward(p, s, a, sp)
-    return (sp, o, r)
-end
-```
+## Which function(s) should I implement for my problem / use in my solver?
+
+Generally, a problem implementer need only implement the simplest one or two of these functions (in addition to some of the functions from POMDPs.jl). That is, only `generate_s` is required from an MDP, and `generate_s` and `generate_o` from a POMDP. Because of the default implementations in `src/GenerativeModels.jl`, all functions will then be available for solvers to use.
+
+If there is a convenient way for the problem to generate a combination of states, observations, and rewards simultaneously (for example, if there is a simulator written in another programming language that generates these from the same function, or if it is computationally convenient to generate `sp` and `o` simultaneously), then the problem writer may wish to directly implement one of the combination `generate_` functions, e.g. `generate_sor()` directly.
+
+Solver writers should use the single function that generates everything that they need and nothing they don't. For example, if the solver needs access to the state, observation, and reward at every timestep, they should use `generate_sor()` rather than `generate_s()` and `generate_or()`, and if the solver needs access to the state and reward, they should use `generate_sr()` rather than `generate_sor()`. This will ensure the widest interoperability between solvers and problems.

--- a/src/GenerativeModels.jl
+++ b/src/GenerativeModels.jl
@@ -2,8 +2,38 @@ module GenerativeModels
 
 using POMDPs
 
-export generate
+export generate_s,
+       generate_o,
+       generate_sr,
+       generate_so,
+       generate_sor
 
+function generate_s{S}(p::POMDP{S}, s, a, rng::AbstractRNG, sp::S=S())
+    td = transition(p, s, a)
+    return rand(rng, td, sp)
+end
+
+function generate_o{S,A,O}(p::POMDP{S,A,O}, s, a, sp, rng::AbstractRNG, o::O=O())
+    od = observation(p, s, a, sp)
+    return rand(rng, od, o)
+end
+
+function generate_sr{S}(p::POMDP{S}, s, a, rng::AbstractRNG, sp::S=S())
+    sp = generate_s(p, s, a, rng)
+    return sp, reward(p, s, a, sp)
+end
+
+function generate_so{S,A,O}(p::POMDP{S,A,O}, s, a, rng::AbstractRNG, sp::S=S(), o::O=O())
+    sp = generate_s(p, s, a, rng, sp)
+    return sp, generate_o(p, s, a, sp, rng, o)
+end
+
+function generate_sor{S,A,O}(p::POMDP{S,A,O}, s, a, rng::AbstractRNG, sp::S=S(), o::O=O())
+    sp,o = generate_so(p, s, a, rng, sp, o)
+    return sp, o, reward(p, s, a, sp)
+end
+
+#=
 function generate{S,A,O}(p::POMDP{S,A,O}, s::S, a::A, rng::AbstractRNG, sp::S=S(), o::O=O())
     td = transition(p, s, a)
     sp = rand(rng, td, sp)
@@ -19,5 +49,6 @@ function generate{S,A}(p::MDP{S,A}, s::S, a::A, rng::AbstractRNG, sp::S=S())
     r = reward(p, s, a, sp)
     return (sp, r)
 end
+=#
 
 end # module

--- a/src/GenerativeModels.jl
+++ b/src/GenerativeModels.jl
@@ -6,6 +6,7 @@ export generate_s,
        generate_o,
        generate_sr,
        generate_so,
+       generate_or,
        generate_sor
 
 function generate_s{S}(p::POMDP{S}, s, a, rng::AbstractRNG, sp::S=S())
@@ -28,27 +29,14 @@ function generate_so{S,A,O}(p::POMDP{S,A,O}, s, a, rng::AbstractRNG, sp::S=S(), 
     return sp, generate_o(p, s, a, sp, rng, o)
 end
 
+function generate_or{S,A,O}(p::POMDP{S,A,O}, s, a, sp, rng::AbstractRNG, o::O=O())
+    return generate_o(p, s, a, sp, rng, o), reward(p, s, a, sp)
+end
+
+
 function generate_sor{S,A,O}(p::POMDP{S,A,O}, s, a, rng::AbstractRNG, sp::S=S(), o::O=O())
     sp,o = generate_so(p, s, a, rng, sp, o)
     return sp, o, reward(p, s, a, sp)
 end
-
-#=
-function generate{S,A,O}(p::POMDP{S,A,O}, s::S, a::A, rng::AbstractRNG, sp::S=S(), o::O=O())
-    td = transition(p, s, a)
-    sp = rand(rng, td, sp)
-    od = observation(p, s, a, sp)
-    o = rand(rng, od, o)
-    r = reward(p, s, a, sp)
-    return (sp, o, r)
-end
-
-function generate{S,A}(p::MDP{S,A}, s::S, a::A, rng::AbstractRNG, sp::S=S())
-    td = transition(p, s, a)
-    sp = rand(rng, td, sp)
-    r = reward(p, s, a, sp)
-    return (sp, r)
-end
-=#
 
 end # module

--- a/src/GenerativeModels.jl
+++ b/src/GenerativeModels.jl
@@ -9,32 +9,32 @@ export generate_s,
        generate_or,
        generate_sor
 
-function generate_s{S}(p::POMDP{S}, s, a, rng::AbstractRNG, sp::S=S())
+function generate_s{S}(p::POMDP{S}, s, a, rng::AbstractRNG, sp::S=create_state(p))
     td = transition(p, s, a)
     return rand(rng, td, sp)
 end
 
-function generate_o{S,A,O}(p::POMDP{S,A,O}, s, a, sp, rng::AbstractRNG, o::O=O())
+function generate_o{S,A,O}(p::POMDP{S,A,O}, s, a, sp, rng::AbstractRNG, o::O=create_observation(p))
     od = observation(p, s, a, sp)
     return rand(rng, od, o)
 end
 
-function generate_sr{S}(p::POMDP{S}, s, a, rng::AbstractRNG, sp::S=S())
+function generate_sr{S}(p::POMDP{S}, s, a, rng::AbstractRNG, sp::S=create_state(p))
     sp = generate_s(p, s, a, rng)
     return sp, reward(p, s, a, sp)
 end
 
-function generate_so{S,A,O}(p::POMDP{S,A,O}, s, a, rng::AbstractRNG, sp::S=S(), o::O=O())
+function generate_so{S,A,O}(p::POMDP{S,A,O}, s, a, rng::AbstractRNG, sp::S=create_state(p), o::O=create_observation(p))
     sp = generate_s(p, s, a, rng, sp)
     return sp, generate_o(p, s, a, sp, rng, o)
 end
 
-function generate_or{S,A,O}(p::POMDP{S,A,O}, s, a, sp, rng::AbstractRNG, o::O=O())
+function generate_or{S,A,O}(p::POMDP{S,A,O}, s, a, sp, rng::AbstractRNG, o::O=create_observation(p))
     return generate_o(p, s, a, sp, rng, o), reward(p, s, a, sp)
 end
 
 
-function generate_sor{S,A,O}(p::POMDP{S,A,O}, s, a, rng::AbstractRNG, sp::S=S(), o::O=O())
+function generate_sor{S,A,O}(p::POMDP{S,A,O}, s, a, rng::AbstractRNG, sp::S=create_state(p), o::O=create_observation(p))
     sp,o = generate_so(p, s, a, rng, sp, o)
     return sp, o, reward(p, s, a, sp)
 end


### PR DESCRIPTION
Hi all,

If anyone is watching this (especially @ebalaban ) I'd appreciate any feedback. I think I am going to switch this interface from having a single `generate()` function to having a `generate_` function for each combination of return values. For example `generate_s()` would return only a state, while `generate_sor()` returns a state observation reward tuple.

There are two reasons for this
1. It was weird for `generate(::POMDP, ...)` to return (s', o, r) and `generate(::MDP, ...)` to return only (s', r)
2. I think this will actually be clearer and more flexible (for example, a solver might just need s and r rather than s, o, and r for a POMDP) for everyone, and it might even be simpler (for example, it seems simpler to just implement `generate_s()` and `reward()` for a problem than `generate` that returns a tuple).

See the spec_ret branch for a complete explanation and documentation.

Does this seem reasonable? Does anyone see any potential consequences/difficulties that I missed?
